### PR TITLE
Feat add LBError

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -313,7 +313,14 @@ func (c *Client) Do(ctx context.Context, req *Request, opts ...RequestOption) (r
 	}
 
 	res, err = c.recv(rc, rp.Metadata.RequestId)
+	if err != nil {
+		return
+	}
 
+	err = res.Err()
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -192,7 +192,9 @@ func (c *Client) reconnecting() {
 
 			if err == nil {
 				c.Logger.Info("reconnect success")
-				c.afterReconnected()
+				if c.afterReconnected != nil {
+					c.afterReconnected()
+				}
 				return
 			}
 

--- a/go/error.go
+++ b/go/error.go
@@ -1,0 +1,23 @@
+package protocol
+
+import (
+	"fmt"
+)
+
+type LBError struct {
+	Status  uint8
+	Code    uint64
+	Message string
+}
+
+func (e *LBError) Error() string {
+	return fmt.Sprintf("longbridge protocol api error, status:%d code:%d message:%s", e.Status, e.Code, e.Message)
+}
+
+func NewError(status uint8, code uint64, msg string) error {
+	return &LBError{
+		Status:  status,
+		Code:    code,
+		Message: msg,
+	}
+}

--- a/go/packet.go
+++ b/go/packet.go
@@ -82,7 +82,7 @@ func (p Packet) CMD() uint32 {
 	return p.Metadata.CmdCode
 }
 
-func (p Packet) Err() *control.Error {
+func (p Packet) Err() error {
 	if p.Metadata.Type != ResponsePacket {
 		return nil
 	}
@@ -100,7 +100,7 @@ func (p Packet) Err() *control.Error {
 		}
 	}
 
-	return &e
+	return NewError(p.Metadata.StatusCode, e.GetCode(), e.GetMsg())
 }
 
 func (p Packet) Unmarshal(v interface{}) error {


### PR DESCRIPTION
add LBError, when call `client.Do`, it will not need to judge `res.Err() == nil`.
If we want to get error code, as follows:
```golang
res, err := cli.Do(context.Background(), &client.Request{
	Cmd: uint32(quote.Command_QuerySecurityStaticInfo),
	Body: &quote.MultiSecurityRequest{
		Symbol: []string{"700.HK", "AAPL.US"},
	},
})
var lbError *LBError
if errors.As(err, &lbError) {
    fmt.Println(lbError.Code)
}

```