### PR TITLE
modify client to interface type

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -21,6 +21,7 @@ var (
 	errConnClosed = errors.New("client conn closed")
 )
 
+// client is an socket client interface
 type Client interface {
 	// Dial using to dial with server
 	Dial(ctx context.Context, u string, handshake *protocol.Handshake, opts ...DialOption) error

--- a/go/client/client_conn.go
+++ b/go/client/client_conn.go
@@ -25,7 +25,7 @@ func GetDialer(scheme string) (DialConnFunc, bool) {
 	return f, ok
 }
 
-type DialConnFunc func(ctx context.Context, cli *Client, uri *url.URL, handshake *protocol.Handshake, opts *DialOptions) (ClientConn, error)
+type DialConnFunc func(ctx context.Context, logger protocol.Logger, uri *url.URL, handshake *protocol.Handshake, opts *DialOptions) (ClientConn, error)
 
 // ClientConn is socket conn abstract
 type ClientConn interface {

--- a/go/client/options.go
+++ b/go/client/options.go
@@ -176,18 +176,18 @@ func RequestTimeout(d time.Duration) RequestOption {
 }
 
 // ClientOption is func to set Client Context and Logger
-type ClientOption func(*Client)
+type ClientOption func(*client)
 
 // WithContext set context of client
 func WithContext(ctx context.Context) ClientOption {
-	return func(c *Client) {
+	return func(c *client) {
 		c.Context = ctx
 	}
 }
 
 // WithLogger set Logger of client
 func WithLogger(l protocol.Logger) ClientOption {
-	return func(c *Client) {
+	return func(c *client) {
 		c.Logger = l
 	}
 }

--- a/go/client/tcp_conn.go
+++ b/go/client/tcp_conn.go
@@ -27,7 +27,7 @@ func parseHostAndPort(p string) (host, port string) {
 	return parts[0], parts[1]
 }
 
-func dialTCPConn(ctx context.Context, cli *Client, uri *url.URL, handshake *protocol.Handshake, o *DialOptions) (ClientConn, error) {
+func dialTCPConn(ctx context.Context, logger protocol.Logger, uri *url.URL, handshake *protocol.Handshake, o *DialOptions) (ClientConn, error) {
 
 	ver := handshake.Version
 	p, err := protocol.GetProtocol(ver)
@@ -49,7 +49,7 @@ func dialTCPConn(ctx context.Context, cli *Client, uri *url.URL, handshake *prot
 	qctx.Version = handshake.Version
 
 	c := &tcpConn{
-		logger:  cli.Logger,
+		logger:  logger,
 		qctx:    qctx,
 		p:       p,
 		conn:    conn,

--- a/go/client/ws_conn.go
+++ b/go/client/ws_conn.go
@@ -24,7 +24,7 @@ func init() {
 
 var ErrInvalidMessage = errors.New("invlaid websocket message")
 
-func dialWSConn(ctx context.Context, cli *Client, uri *url.URL, handshake *protocol.Handshake, o *DialOptions) (ClientConn, error) {
+func dialWSConn(ctx context.Context, logger protocol.Logger, uri *url.URL, handshake *protocol.Handshake, o *DialOptions) (ClientConn, error) {
 	ver := handshake.Version
 	p, err := protocol.GetProtocol(ver)
 
@@ -51,7 +51,7 @@ func dialWSConn(ctx context.Context, cli *Client, uri *url.URL, handshake *proto
 	qctx.Version = handshake.Version
 
 	c := &wsConn{
-		logger:  cli.Logger,
+		logger:  logger,
 		qctx:    qctx,
 		p:       p,
 		conn:    conn,


### PR DESCRIPTION
Use client interface instead of struct. Support for users can mock this client. 
This is a broken change.