### PR TITLE
fix: concurrent call ClientConn.Close result in close of closed channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 **/go.work
+.idea


### PR DESCRIPTION
```go
func (conn *wsConn) Close(err error) {
	if conn.closed() {
		return
	}

	conn.logger.Errorf("close conn, err: %v", err)
	close(conn.closeCh)
	close(conn.writeCh)

	conn.conn.Close()

	conn.DispatchClose(err)
}
```

```
2024/12/12 21:01:28.645455 logger.go:190: [Error] [[github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close](http://github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close)] close conn, err: websocket: close 1006 (abnormal closure): unexpected EOF
2024/12/12 21:01:28.645677 logger.go:190: [Error] [[github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close](http://github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close)] close conn, err: write tcp [127.0.0.1:49976](http://127.0.0.1:49976/)->[127.0.0.1:7890](http://127.0.0.1:7890/): write: broken pipe
panic: close of closed channel

goroutine 85789765 [running]:
[github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close](http://github.com/longportapp/openapi-protocol/go/client.(*wsConn).Close)(0xc0066706c0, {0x1c67440, 0xc0054d4df0})
	/home/runner/go/pkg/mod/[github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:196](http://github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:196) +0xb8
[github.com/longportapp/openapi-protocol/go/client.(*wsConn).writing(0xc0066706c0)](http://github.com/longportapp/openapi-protocol/go/client.(*wsConn).writing(0xc0066706c0))
	/home/runner/go/pkg/mod/[github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:314](http://github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:314) +0xb9
created by [github.com/longportapp/openapi-protocol/go/client.(*wsConn).communicating](http://github.com/longportapp/openapi-protocol/go/client.(*wsConn).communicating) in goroutine 85789674
	/home/runner/go/pkg/mod/[github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:206](http://github.com/longportapp/openapi-protocol/go@v0.4.0/client/ws_conn.go:206) +0x96
```