### PR TITLE
fix: recursive call `conn.closeOnce.Do` cause dead lock

### DIFF
--- a/go/client/tcp_conn.go
+++ b/go/client/tcp_conn.go
@@ -169,17 +169,16 @@ func (conn *tcpConn) OnPacket(fn func(*protocol.Packet, error)) {
 }
 
 func (conn *tcpConn) Close(err error) {
+	if conn.closed() {
+		return
+	}
 	// Close can only invoke once
 	conn.closeOnce.Do(func() {
-		if conn.closed() {
-			return
-		}
-
 		conn.logger.Errorf("close conn, err: %v", err)
 		close(conn.closeCh)
 		close(conn.writeCh)
 
-		conn.conn.Close()
+		_ = conn.conn.Close()
 
 		conn.DispatchClose(err)
 	})

--- a/go/client/ws_conn.go
+++ b/go/client/ws_conn.go
@@ -189,17 +189,16 @@ func (conn *wsConn) OnPacket(fn func(*protocol.Packet, error)) {
 }
 
 func (conn *wsConn) Close(err error) {
+	if conn.closed() {
+		return
+	}
 	// Close can only invoke once
 	conn.closeOnce.Do(func() {
-		if conn.closed() {
-			return
-		}
-
 		conn.logger.Errorf("close conn, err: %v", err)
 		close(conn.closeCh)
 		close(conn.writeCh)
 
-		conn.conn.Close()
+		_ = conn.conn.Close()
 
 		conn.DispatchClose(err)
 	})


### PR DESCRIPTION
A recursive call to `conn.closeOnce.Do` here will lead to a deadlock, and consequently, `client.reconnecting` will never be executed successfully.

```go
func (conn *wsConn) Close(err error) {
	// Close can only invoke once
	conn.closeOnce.Do(func() {
		if conn.closed() {
			return
		}

		conn.logger.Errorf("close conn, err: %v", err)
		close(conn.closeCh)
		close(conn.writeCh)

		conn.conn.Close()

		conn.DispatchClose(err)
	})
}
```

https://github.com/longportapp/openapi-protocol/blob/018f5f5a9aea914a0815a9a322bb7b4c21843218/go/client/ws_conn.go#L204

```go
func (c *client) onConnClose(err error) {
	select {
	case <-c.closeCh:
		return
	default:
	}

	c.Logger.Debugf("reconnect for conn closed: %v", err)

	c.reconnecting()
}
```

https://github.com/longportapp/openapi-protocol/blob/018f5f5a9aea914a0815a9a322bb7b4c21843218/go/client/client.go#L173

```go
func (c *client) reconnect() error {
	if c.dialOptions.MaxReconnect > 0 {
		if c.reconnectCount >= c.dialOptions.MaxReconnect {
			return ErrHitMaxReconnect
		}
	}

	c.reconnectCount = c.reconnectCount + 1

	if c.conn != nil {
		c.conn.Close(errors.New("close old conn for reconnect"))
	}

	c.recvsMu.Lock()
	for _, ch := range c.recvs {
		close(ch)
	}
	c.recvs = make(map[uint32]chan *protocol.Packet)
	c.recvsMu.Unlock()

	dialer, _ := GetDialer(c.addr.Scheme)

	ctx, cancel := context.WithTimeout(c.Context, c.dialOptions.Timeout)
	defer cancel()

	if err := c.dial(ctx, dialer); err != nil {
		return err
	}

	// server needn't auth
	if c.authInfo == nil {
		return nil
	}

	// do auth
	if c.isAuthExpired() {
		return c.auth()
	}

	return c.reconnectDial()
}
```

https://github.com/longportapp/openapi-protocol/blob/018f5f5a9aea914a0815a9a322bb7b4c21843218/go/client/client.go#L264