### PR TITLE
chore: migrate from longportapp to longbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Longbridge Binary Protocol is using for OpenAPI Socket Connection.
 
-[More details](https://open.longportapp.com/docs/socket/protocol/overview)
+[More details](https://open.longbridge.com/docs/socket/protocol/overview)
 
 For `Python` and `C++` user, we provide:
 
-- [Python SDK](https://github.com/longportapp/openapi-sdk/tree/master/python)
-- [C++ SDK](https://github.com/longportapp/openapi-sdk/tree/master/cpp)
-- [Java SDK](https://github.com/longportapp/openapi-sdk/tree/master/java)
-- [C SDK](https://github.com/longportapp/openapi-sdk/tree/master/c)
-- [Rust SDK](https://github.com/longportapp/openapi-sdk/tree/master/rust)
-- [NodeJS SDK](https://github.com/longportapp/openapi-sdk/tree/master/nodejs)
+- [Python SDK](https://github.com/longbridge/openapi-sdk/tree/master/python)
+- [C++ SDK](https://github.com/longbridge/openapi-sdk/tree/master/cpp)
+- [Java SDK](https://github.com/longbridge/openapi-sdk/tree/master/java)
+- [C SDK](https://github.com/longbridge/openapi-sdk/tree/master/c)
+- [Rust SDK](https://github.com/longbridge/openapi-sdk/tree/master/rust)
+- [NodeJS SDK](https://github.com/longbridge/openapi-sdk/tree/master/nodejs)
 
 This repo want to show how to implement Longbridge Binary Protocol.
 
@@ -19,7 +19,7 @@ If you are `Gopher`, you can use the golang implementation to connect our socket
 
 ## Golang Implementation
 
-Check code [here](https://github.com/longportapp/openapi-protocol/tree/main/go).
+Check code [here](https://github.com/longbridge/openapi-protocol/tree/main/go).
 
 code structure:
 
@@ -28,4 +28,4 @@ code structure:
 - go/v1 - protocol version 1 implement
 - go/v2 - protocol version 2 implement
 
-Example is [here](https://github.com/longportapp/openapi-protocol/tree/main/examples/go)
+Example is [here](https://github.com/longbridge/openapi-protocol/tree/main/examples/go)

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
 # Golang example
 
-Before run the example code, your should get the [socket token](https://open.longportapp.com/en/docs/socket-token-api) first.
+Before run the example code, your should get the [socket token](https://open.longbridge.com/en/docs/socket-token-api) first.
 
 ## run quote example
 

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -3,8 +3,8 @@ module main
 go 1.18
 
 require (
-	github.com/longportapp/openapi-protobufs/gen/go v0.2.1
-	github.com/longportapp/openapi-protocol/go v0.3.0
+	github.com/longbridge/openapi-protocol/go v0.3.0
+	github.com/longbridge/openapi-protobufs/gen/go v0.7.0
 )
 
 require (

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -8,10 +8,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/longbridgeapp/assert v0.1.0 h1:KkQlHUJSpuUFkUDjwBJgghFl31+wwSDHTq/WRrvLjko=
-github.com/longportapp/openapi-protobufs/gen/go v0.2.1 h1:AaubbUBGkawGYR4+XMorOIHr9Drte2CZBwjEKp6C1mU=
-github.com/longportapp/openapi-protobufs/gen/go v0.2.1/go.mod h1:/chiEwEW4CnOVgKTaCf8rQUwes00Ku8q1CvRpOueWfo=
-github.com/longportapp/openapi-protocol/go v0.3.0 h1:Zv8YEkmkmbdZvbExunR5tHI8/DvjmidNK4vLy5ZHvUY=
-github.com/longportapp/openapi-protocol/go v0.3.0/go.mod h1:bO8FSq+4Iyg1UPZ5zoBS8V5xgSVXl0gA+Iw5nhWGpdo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/go/quote/example_quote.go
+++ b/examples/go/quote/example_quote.go
@@ -5,10 +5,10 @@ import (
 	"flag"
 	"log"
 
-	quote "github.com/longportapp/openapi-protobufs/gen/go/quote"
-	protocol "github.com/longportapp/openapi-protocol/go"
-	"github.com/longportapp/openapi-protocol/go/client"
-	_ "github.com/longportapp/openapi-protocol/go/v1"
+	quote "github.com/longbridge/openapi-protobufs/gen/go/quote"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	"github.com/longbridge/openapi-protocol/go/client"
+	_ "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 func main() {

--- a/examples/go/trade/example_trade.go
+++ b/examples/go/trade/example_trade.go
@@ -5,11 +5,11 @@ import (
 	"flag"
 	"log"
 
-	trade "github.com/longportapp/openapi-protobufs/gen/go/trade"
+	trade "github.com/longbridge/openapi-protobufs/gen/go/trade"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	"github.com/longportapp/openapi-protocol/go/client"
-	_ "github.com/longportapp/openapi-protocol/go/v1"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	"github.com/longbridge/openapi-protocol/go/client"
+	_ "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 func main() {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,1 +1,1 @@
-github.com/longportapp/openapi-protocol/go v0.3.0/go.mod h1:bO8FSq+4Iyg1UPZ5zoBS8V5xgSVXl0gA+Iw5nhWGpdo=
+github.com/longbridge/openapi-protocol/go v0.3.0/go.mod h1:bO8FSq+4Iyg1UPZ5zoBS8V5xgSVXl0gA+Iw5nhWGpdo=

--- a/go/README.md
+++ b/go/README.md
@@ -2,4 +2,4 @@
 
 ## Usage
 
-Show in [example/go](https://github.com/longportapp/openapi-protocol/tree/main/examples/go)
+Show in [example/go](https://github.com/longbridge/openapi-protocol/tree/main/examples/go)

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 
-	control "github.com/longportapp/openapi-protobufs/gen/go/control"
+	control "github.com/longbridge/openapi-protobufs/gen/go/control"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 )

--- a/go/client/client_conn.go
+++ b/go/client/client_conn.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 var connDialers = make(map[string]DialConnFunc)

--- a/go/client/client_test.go
+++ b/go/client/client_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	control "github.com/longportapp/openapi-protobufs/gen/go/control"
+	control "github.com/longbridge/openapi-protobufs/gen/go/control"
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 func init() {

--- a/go/client/options.go
+++ b/go/client/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 var (

--- a/go/client/tcp_conn.go
+++ b/go/client/tcp_conn.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/Allenxuxu/ringbuffer"
-	protocol "github.com/longportapp/openapi-protocol/go"
-	_ "github.com/longportapp/openapi-protocol/go/v1"
-	_ "github.com/longportapp/openapi-protocol/go/v2"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	_ "github.com/longbridge/openapi-protocol/go/v1"
+	_ "github.com/longbridge/openapi-protocol/go/v2"
 	"github.com/pkg/errors"
 )
 

--- a/go/client/ws_conn.go
+++ b/go/client/ws_conn.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	control "github.com/longportapp/openapi-protobufs/gen/go/control"
+	control "github.com/longbridge/openapi-protobufs/gen/go/control"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	_ "github.com/longportapp/openapi-protocol/go/v1"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	_ "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 func init() {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/longportapp/openapi-protocol/go
+module github.com/longbridge/openapi-protocol/go
 
 go 1.17
 
@@ -6,8 +6,8 @@ require (
 	github.com/Allenxuxu/ringbuffer v0.0.11
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
+	github.com/longbridge/openapi-protobufs/gen/go v0.7.0
 	github.com/longbridgeapp/assert v0.1.0
-	github.com/longportapp/openapi-protobufs/gen/go v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.28.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -15,10 +15,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/longbridge/openapi-protobufs/gen/go v0.7.0 h1:AP5rxymZqDVMBQ8hR9hntvFa9ScOoXIdNVzXE6xtJic=
+github.com/longbridge/openapi-protobufs/gen/go v0.7.0/go.mod h1:+wh92EcM7YJ+Puc6nZf9duFIXGNYI1GJbnvE+PaDtdY=
 github.com/longbridgeapp/assert v0.1.0 h1:KkQlHUJSpuUFkUDjwBJgghFl31+wwSDHTq/WRrvLjko=
 github.com/longbridgeapp/assert v0.1.0/go.mod h1:ew3umReliXtk1bBG4weVURxdvR0tsN+rCEfjnA4YfxI=
-github.com/longportapp/openapi-protobufs/gen/go v0.4.0 h1:+wD5sq/DZS7HCUL6nOe7v7nNuM1EvuEDluk69f2+2nM=
-github.com/longportapp/openapi-protobufs/gen/go v0.4.0/go.mod h1:/chiEwEW4CnOVgKTaCf8rQUwes00Ku8q1CvRpOueWfo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go/packet.go
+++ b/go/packet.go
@@ -3,7 +3,7 @@ package protocol
 import (
 	"encoding/json"
 
-	control "github.com/longportapp/openapi-protobufs/gen/go/control"
+	control "github.com/longbridge/openapi-protobufs/gen/go/control"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 )

--- a/go/v1/header.go
+++ b/go/v1/header.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Allenxuxu/ringbuffer"
 	"github.com/pkg/errors"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 var ErrUnknowPacket = errors.New("invalid packet type")

--- a/go/v1/header_test.go
+++ b/go/v1/header_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Allenxuxu/ringbuffer"
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 func TestHeader_Pack(t *testing.T) {

--- a/go/v1/v1.go
+++ b/go/v1/v1.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/Allenxuxu/ringbuffer"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	"github.com/longportapp/openapi-protocol/go/gzip"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	"github.com/longbridge/openapi-protocol/go/gzip"
 )
 
 func init() {

--- a/go/v1/v1_test.go
+++ b/go/v1/v1_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Allenxuxu/ringbuffer"
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
+	protocol "github.com/longbridge/openapi-protocol/go"
 )
 
 var v1 = &protocolV1{}

--- a/go/v2/v2.go
+++ b/go/v2/v2.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/Allenxuxu/ringbuffer"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	"github.com/longportapp/openapi-protocol/go/gzip"
-	v1 "github.com/longportapp/openapi-protocol/go/v1"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	"github.com/longbridge/openapi-protocol/go/gzip"
+	v1 "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 func init() {

--- a/go/v2/v2_header.go
+++ b/go/v2/v2_header.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/Allenxuxu/ringbuffer"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	v1 "github.com/longportapp/openapi-protocol/go/v1"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	v1 "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 const MaxMetadataLength = 1<<16 - 1

--- a/go/v2/v2_header_test.go
+++ b/go/v2/v2_header_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/Allenxuxu/ringbuffer"
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/longportapp/openapi-protocol/go"
-	v1 "github.com/longportapp/openapi-protocol/go/v1"
+	protocol "github.com/longbridge/openapi-protocol/go"
+	v1 "github.com/longbridge/openapi-protocol/go/v1"
 )
 
 func TestHeader_Pack(t *testing.T) {


### PR DESCRIPTION
## 变更说明

- **包名**: \github.com/longportapp/openapi-protocol\ → \github.com/longbridge/openapi-protocol\
- **openapi-protobufs**: 依赖改为 \github.com/longbridge/openapi-protobufs/gen/go v0.7.0\
- **文档链接**: README 中的文档与各语言 SDK 链接更新为 longbridge 域名与组织

仓库已迁移至 longbridge 组织，本 PR 完成包名与依赖的同步更新。

Made with [Cursor](https://cursor.com)