### PR TITLE
chore: update example to use openapi-protocol/go v0.5.0

### DIFF
--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -3,7 +3,7 @@ module main
 go 1.18
 
 require (
-	github.com/longbridge/openapi-protocol/go v0.3.0
+	github.com/longbridge/openapi-protocol/go v0.5.0
 	github.com/longbridge/openapi-protobufs/gen/go v0.7.0
 )
 


### PR DESCRIPTION
将 examples/go 的依赖从 \github.com/longbridge/openapi-protocol/go v0.3.0\ 升级为 \0.5.0\。

Made with [Cursor](https://cursor.com)